### PR TITLE
fix/tank-str-scalar

### DIFF
--- a/Fight.py
+++ b/Fight.py
@@ -493,7 +493,7 @@ def ComputeDamage(Player, Potency, Enemy, SpellBonus, type, spellObj):
     if isinstance(Player, Queen) or isinstance(Player, Esteem) or isinstance(Player, Shadow) or isinstance(Player, BigSummon): MainStat = Player.Stat["MainStat"] #Summons do not receive bonus
     else: MainStat = math.floor(Player.Stat["MainStat"] * 1.05 )# Player.CurrentFight.TeamCompositionBonus) #Scaling %bonus on mainstat
     #Computing values used throughout all computations
-    if isinstance(Player, Tank) : f_MAIN_DMG = (100+math.floor((MainStat-baseMain)*153/baseMain))/100 #Tanks have a difference constant 
+    if isinstance(Player, Tank) : f_MAIN_DMG = (100+math.floor((MainStat-baseMain)*156/baseMain))/100 #Tanks have a difference constant 
     else: f_MAIN_DMG = (100+math.floor((MainStat-baseMain)*195/baseMain))/100
     #These values are all already computed since they do not change
     f_WD = Player.f_WD


### PR DESCRIPTION
This scalar is wrong for level 90 tanks. At least from the info I got through an Allagan Studies theorycrafter for Etro and this tank damage calculator:

https://bit.ly/XIV-TANKDPSCALC-EW