### PR TITLE
switch to pathlib for paths

### DIFF
--- a/ffxivppscalc/UI_backend.py
+++ b/ffxivppscalc/UI_backend.py
@@ -1,6 +1,7 @@
 import copy
 import json
 import os
+from pathlib import Path
 from Jobs.Melee.Monk.Monk_Spell import ComboEffect
 
 from Jobs.Melee.Ninja.Ninja_Spell import ApplyHuton
@@ -253,8 +254,8 @@ def SaveFight(Event, countdown, fightDuration, saveName):
                 },
                 "PlayerList" : PlayerListDict
     }}
-    save_dir = os.getcwd() + "\\saved"
-    with open(save_dir + "\\" + saveName + ".json", "w") as write_files:
+    save_dir: Path = Path.cwd() / 'saved'
+    with open(save_dir / f'{saveName}.json', "w") as write_files:
         json.dump(data,write_files, indent=4) #saving file
 
 
@@ -472,6 +473,6 @@ def MergeFightBackEnd(child_fight, parent_fight, parent_name):
 
     data_parent["data"]["PlayerList"] += data_child["data"]["PlayerList"]
 
-    save_dir = os.getcwd() + "\\saved"
-    with open(save_dir + "\\" + parent_name, "w") as write_files:
+    save_dir: Path = Path.cwd() / "saved"
+    with open(save_dir / parent_name, "w") as write_files:
         json.dump(data_parent,write_files, indent=4) #saving file


### PR DESCRIPTION
This is a bit more of a "please read over this to make sure this actually works the way you expect" PR, since I haven't finished reading all the code yet. But in the last PR, you mentioned relative paths, so I figured this might be inroads to making your life easier.

Python has a stdlib agnostic path library called [pathlib](https://docs.python.org/3/library/pathlib.html), with some nice features:

```python
>>> from pathlib import Path
>>> Path.cwd()
PosixPath('/Users/king/Projects/nonowazu/FFXIVPPSCalculator')
>>> Path.cwd() / 'saved'
PosixPath('/Users/king/Projects/nonowazu/FFXIVPPSCalculator/saved')
>>> (Path.cwd() / 'saved').exists()
True
```

It overloads the `/` operator to let you append paths, and it'll figure out if it needs to be `C:\windows\style\paths` or `/unix/style/paths` based on the system. Also, functions like `open` can take a Path object since they downgrade to a string path for opening. Since I do 99% of my dev work on linux or mac, some of these paths wouldn't work quite right for me, but pathlib should handle it automagically.