### PR TITLE
Add console scripts and clean up cli a bit

### DIFF
--- a/ffxivcalc/__main__.py
+++ b/ffxivcalc/__main__.py
@@ -1,5 +1,6 @@
 """CLI entrypoint for FFXIV-Combat-Simulator"""
 from argparse import ArgumentParser
+from pathlib import Path
 from sys import exit
 
 from ffxivcalc import __name__ as prog
@@ -13,20 +14,21 @@ def get_parser() -> ArgumentParser:
     :return: An ArgumentParser object
     """
     parser = ArgumentParser(prog=prog)
+    subparsers = parser.add_subparsers(help='action to perform', dest='action')
 
     # Running in code simulation
-    parser.add_argument('-code_simulation', '--code-simulation', type=bool, default=False)
-    parser.add_argument('-s', '--step-size', type=float, default=0.01)
-    parser.add_argument('-l', '--time-limit', type=int, default=1000)
+    simulation_parser = subparsers.add_parser('simulate')
+    simulation_parser.add_argument('-code_simulation', '--code-simulation', type=bool, default=False)
+    simulation_parser.add_argument('-s', '--step-size', type=float, default=0.01)
+    simulation_parser.add_argument('-l', '--time-limit', type=int, default=1000)
 
     # Running tester
-    parser.add_argument('-run_tests', '--run_tests', type=bool, default=False)
+    test_parser = subparsers.add_parser('tests')
+    test_parser.add_argument('json', type=Path, help='path to test json', nargs='?', default='test_layout.json')
 
-    # Running tester
-    parser.add_argument('-TUI', '--TUI_open', type=bool, default=False)
+    # Running tui
+    subparsers.add_parser('tui')
 
-
-    # subparsers should be added here for tui/gui/etc functionality
     return parser
 
 
@@ -40,12 +42,16 @@ def main() -> int:
     args = parser.parse_args()
     #input(args)
 
-    if args.code_simulation:
-        fight_main(False, time_unit=args.step_size, TimeLimit=args.time_limit)
-    elif args.run_tests:
-        Tester("test_layout.json").Test()
-    elif args.TUI_open:
-        TUI_draw()
+    match args.action:
+        case 'simulate':
+            fight_main(False, time_unit=args.step_size, TimeLimit=args.time_limit)
+        case 'tests':
+            Tester(args.json).Test()
+        case 'tui':
+            TUI_draw()
+        case _: # default case
+            parser.print_help()
+
     return 0
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,6 +14,10 @@ include_package_data = True
 packages = find:
 install_requires = file: requirements.txt
 
+[options.entry_points]
+console_scripts =
+    ffxivcalc = ffxivcalc.__main__:main
+
 [options.packages.find]
 exclude =
     Fun Stuff if you're bored*


### PR DESCRIPTION
This makes two changes:

1. Make `ffxivcalc` a console script:
```
$ python -mvenv env
$ . env/bin/activate
(env) $ pip install --editable .
Obtaining file:///Users/king/Projects/nonowazu/FFXIVPPSCalculator
[----->8 console stuff here -----]
(env) $ ffxivcalc --help
usage: ffxivcalc [-h] {simulate,tests,tui} ...

positional arguments:
  {simulate,tests,tui}  action to perform

options:
  -h, --help            show this help message and exit
(env) $ which ffxivcalc
/Users/king/Projects/nonowazu/FFXIVPPSCalculator/env/bin/ffxivcalc
```
2. clean up the console script to have actions (seen above as possible things to do); you can pull up the help for each action as appropriate:
```
$ ffxivcalc simulate --help
usage: ffxivcalc simulate [-h] [-code_simulation CODE_SIMULATION] [-s STEP_SIZE] [-l TIME_LIMIT]

options:
  -h, --help            show this help message and exit
  -code_simulation CODE_SIMULATION, --code-simulation CODE_SIMULATION
  -s STEP_SIZE, --step-size STEP_SIZE
  -l TIME_LIMIT, --time-limit TIME_LIMIT
```
(though `tests` has a default option and `tui` has no option, you can look at the `tests` and `simulate` action to see how to implement those)