### PR TITLE
Add in optional 'verbosity' logging to cli

### DIFF
--- a/ffxivcalc/__main__.py
+++ b/ffxivcalc/__main__.py
@@ -2,11 +2,14 @@
 from argparse import ArgumentParser
 from pathlib import Path
 from sys import exit
+import logging
 
 from ffxivcalc import __name__ as prog
 from ffxivcalc.UI.SimulationInput import ExecuteMemoryCode as fight_main
 from ffxivcalc.Tester.Tester import Tester
 from ffxivcalc.UI.TUI import TUI_draw
+
+__logger__ = logging.getLogger() # root logger
 
 def get_parser() -> ArgumentParser:
     """Defines all the cli arguments to be parsed
@@ -14,6 +17,7 @@ def get_parser() -> ArgumentParser:
     :return: An ArgumentParser object
     """
     parser = ArgumentParser(prog=prog)
+    parser.add_argument('-v', '--verbose', action='count', default=0)
     subparsers = parser.add_subparsers(help='action to perform', dest='action')
 
     # Running in code simulation
@@ -40,7 +44,19 @@ def main() -> int:
     """
     parser = get_parser()
     args = parser.parse_args()
-    #input(args.json)
+
+    if args.verbose > 0:
+        match args.verbose:
+            case 1:
+                level = logging.ERROR
+            case 2:
+                level = logging.INFO
+            case 3:
+                level = logging.DEBUG
+            case _: # more than 3 V is too much
+                level = logging.DEBUG
+        logging.basicConfig(format='[%(levelname)s] %(message)s')
+        __logger__.setLevel(level=level)
 
     match args.action:
         case 'simulate':


### PR DESCRIPTION
No real logging happening yet, but to add logging to any module, you can do the following:

```python
import logging

__logger__ = logging.getLogger(__name__)

# anywhere in your code
__logging__.debug('This is my debug message')
```

I also tweaked the format a little bit, it looks like these sorts of messages:

```
[INFO] set up logger
[DEBUG] foo bar baz
```

It may be more valuable to log more, or make debug logging have a more verbose like, but that's tweakable.