### PR TITLE
[bug-fixes] Fix sch mit exceptions, higan potency 60->45

### DIFF
--- a/ffxivcalc/Jobs/Healer/Scholar/Scholar_Spell.py
+++ b/ffxivcalc/Jobs/Healer/Scholar/Scholar_Spell.py
@@ -82,7 +82,7 @@ def ApplyFeyIllumination(Player, Enemy):
 
     for player in Player.CurrentFight.PlayerList:
         player.AddHealingBuff(HealingBuff(1.1, 20, player, GivenHealBuff=False, BuffName="FeyIllumination"))
-        player.AddMitBuff(MitBuff(1.05, 20, player, MagicMit=True, BuffName="FeyIllumination"))
+        player.AddMitBuff(MitBuff(0.95, 20, player, MagicMit=True, BuffName="FeyIllumination"))
 
 def ApplyWhisperingDawn(Player, Enemy):
     Player.WhisperingDawnCD = 60
@@ -113,7 +113,7 @@ def ApplySacredSoil(Player, Enemy):
     Player.AetherFlowStack -= 1
 
     for player in Player.CurrentFight.PlayerList:
-        player.AddMitBuff(MitBuff(1.1, 15, player, BuffName="SacredSoil"))
+        player.AddMitBuff(MitBuff(0.9, 15, player, BuffName="SacredSoil"))
 
 def ApplyExcogitation(Player, Enemy):
     Player.ExcogitationCD = 45
@@ -127,7 +127,7 @@ def ApplyExpedient(Player, Enemy):
     Player.ExpedientCD = 120
 
     for player in Player.CurrentFight.PlayerList:
-        player.AddMitBuff(MitBuff(1.1, 20, player, BuffName="Expedient"))
+        player.AddMitBuff(MitBuff(0.9, 20, player, BuffName="Expedient"))
 
 def ApplyProtraction(Player, Enemy):
     Player.ProtractionCD = 60

--- a/ffxivcalc/Jobs/Melee/Samurai/Samurai_Spell.py
+++ b/ffxivcalc/Jobs/Melee/Samurai/Samurai_Spell.py
@@ -398,7 +398,7 @@ Enpi = SamuraiSpell(7486, True, 0, 2.5, 100, Add10Kenki, [], 0, type = 2)
 
 #Iaijutsu
 Higanbana = SamuraiSpell(7489, True, 1.3, 2.5, 200, ApplyHiganbana, [HiganbanaRequirement], 0, type = 2)
-HiganbanaDOT = DOTSpell(-1, 60, True)
+HiganbanaDOT = DOTSpell(-1, 45, True)
 TenkaGoken = SamuraiSpell(7488, True, 1.3, 2.5, 300, ApplyTenkaGoken, [TenkaGokenRequirement], 0, type = 2)
 Midare = SamuraiSpell(7487, True, 1.3, 2.5, 640, ApplyMidare, [MidareRequirement], 0, type = 2)
 

--- a/ffxivcalc/Jobs/Player.py
+++ b/ffxivcalc/Jobs/Player.py
@@ -22,7 +22,7 @@ class MitBuff:
     also keeps track of the timer of such a buff.
 
     Returns:
-        PercentMit (float) : Percent damage taken of the mitigation. So if 30% mit, PercentMit = 0.7
+        PercentMit (float) : Percentage of the original damage taken once mitigation is applied. So if 30% mit, PercentMit = 0.7
         Timer (float) : Timer of the mit
         Player (Player) : Player on which the mit is applied
         MagicMit (bool) : If the Mit is only for magic damage

--- a/ffxivcalc/Jobs/Tank/Paladin/Paladin_Spell.py
+++ b/ffxivcalc/Jobs/Tank/Paladin/Paladin_Spell.py
@@ -71,7 +71,9 @@ def ApplyHallowedGround(Player, Enemy):
 
 def ApplyBulwark(Player, Enemy):
     Player.BulwarkCD = 90
-    BulwarkMit = MitBuff(20, 10, Player)
+    # TODO: clarify block vs normal mit
+    # Block has no affect on dots.
+    BulwarkMit = MitBuff(0.8, 10, Player)
 
     Player.MitBuffList.append(BulwarkMit)
 


### PR DESCRIPTION
Changes
* Converted all sch mits to [0, 1.0] to avoid exceptions when using them in the tool
* fixed higanbana potency to 45 (from 60) https://na.finalfantasyxiv.com/jobguide/samurai/
* Checks other mit usage, "fixed" pld bulwark.

Attached is an error when using `Expedient` in the tool. 

Given documentation of `MitBuff`, this checks out
```
        PercentMit (float) : Percent damage taken of the mitigation. So if 30% mit, PercentMit = 0.7
```
![Screenshot 2024-02-08 001441](https://github.com/IAmPythagoras/FFXIV-Combat-Simulator/assets/18486679/a731b7b1-d25f-4dcc-bf9f-531094f7f0c5)
